### PR TITLE
Bug 932779: Support disabling NFC power management

### DIFF
--- a/src/broadcom/PowerSwitch.cpp
+++ b/src/broadcom/PowerSwitch.cpp
@@ -12,6 +12,7 @@
 #undef LOG_TAG
 #define LOG_TAG "BroadcomNfc"
 #include <cutils/log.h>
+#include <cutils/properties.h>
 
 void doStartupConfig();
 
@@ -35,6 +36,15 @@ PowerSwitch::~PowerSwitch()
 PowerSwitch& PowerSwitch::getInstance()
 {
   return sPowerSwitch;
+}
+
+bool PowerSwitch::powerManagementIsEnabled()
+{
+  char value[PROPERTY_VALUE_MAX];
+
+  int len = property_get("ro.moz.nfc.disable_powermgmt", value, "false");
+
+  return !(len && !strcmp(value, "true"));
 }
 
 void PowerSwitch::initialize(PowerLevel level)

--- a/src/broadcom/PowerSwitch.h
+++ b/src/broadcom/PowerSwitch.h
@@ -49,7 +49,7 @@ public:
 
   /**
    * Power level is unknown.
-   */  
+   */
   static const int PLATFORM_UNKNOWN_LEVEL = 0;
   /**
    * The phone is turned OFF.
@@ -81,6 +81,13 @@ public:
    * @return Reference to this object.
    */
   static PowerSwitch& getInstance();
+
+  /**
+   * Check if power management is enabled
+   *
+   * @return True if power management is enabled (the default).
+   */
+  static bool powerManagementIsEnabled();
 
   /**
    * Initialize member variables.


### PR DESCRIPTION
Power management is a lot of work to emulate. With this patch
it's possible to turn off power management by setting a property
in the environment. The default is to turn on power management.

Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
