### PR TITLE
Bug 939450 - B2G NFC: nfcd does not handle handover protocol correctly

### DIFF
--- a/src/handover/HandoverClient.h
+++ b/src/handover/HandoverClient.h
@@ -14,8 +14,11 @@ public:
   ~HandoverClient();
 
   bool connect();
-  void put(NdefMessage& msg);
+  NdefMessage* receive();
+  bool put(NdefMessage& msg);
   void close();
+
+  NdefMessage* processHandoverRequest(NdefMessage& msg);
 
 private:
   static const int DEFAULT_MIU = 128;


### PR DESCRIPTION
The root cause is handover select is returned by client socket. So after sending handover request, nfcd should try receiving data from client socket.
