### PR TITLE
Bug 940858 - B2G NFC: NFC Daemon should send handover select response th...

### DIFF
--- a/src/handover/HandoverServer.h
+++ b/src/handover/HandoverServer.h
@@ -6,6 +6,8 @@
 #define mozilla_nfcd_HandoverPushServer_h
 
 class IHandoverCallback;
+class NdefMessage;
+class HandoverConnectionThread;
 
 class HandoverServer{
 public:
@@ -18,11 +20,16 @@ public:
 
   void start();
   void stop();
+  bool put(NdefMessage& msg);
+  void setConnectionThread(HandoverConnectionThread* pThread);
 
   ILlcpServerSocket* mServerSocket;
   int                mServiceSap;
   IHandoverCallback* mCallback;
   bool               mServerRunning;
+
+private:
+  HandoverConnectionThread* mConnectionThread;
 };
 
 class HandoverConnectionThread {
@@ -33,6 +40,11 @@ public:
   void run();
   bool isServerRunning() const;
 
+  ILlcpSocket* getSocket() {  return mSock;  }
+  IHandoverCallback* getCallback() {  return mCallback;  }
+  HandoverServer* getServer() {  return mServer;  }
+
+private:
   ILlcpSocket* mSock;
   IHandoverCallback* mCallback;
   HandoverServer* mServer;


### PR DESCRIPTION
Handover select message should be sent through handover server instead of handover client.
Because handover select message is used to response handover request message and should be sent by using same socket as receiving handover request.

And handover request is always received by handover server
