### PR TITLE
Bug 941433 - NFC Daemon could not detect tag

### DIFF
--- a/src/broadcom/NfcTagManager.h
+++ b/src/broadcom/NfcTagManager.h
@@ -204,8 +204,8 @@ public:
   int connectWithStatus(int technology);
   int reconnectWithStatus(int technology);
   int reconnectWithStatus();
-  int checkNdefWithStatus(int ndefinfo[]);
-  void readNdef(std::vector<uint8_t>& buf);
+  NdefMessage* doReadNdef();
+  NdefDetail* doReadNdefDetail();
   bool isNdefFormatable();
 
 private:


### PR DESCRIPTION
The root cause is that NfcTagManager have a mutex "mMutex" to prevent multiple API call at the same time.
so the mutex should only exist in API function.
If the mutex is exist in internal function, when API function call internal function, it will cause dead lock.
