### PR TITLE
Bug 941208 - B2G NFC: nfcd prints internal error message during handover

### DIFF
--- a/src/handover/HandoverServer.cpp
+++ b/src/handover/HandoverServer.cpp
@@ -193,7 +193,7 @@ bool HandoverServer::put(NdefMessage& msg)
 
 void HandoverServer::setConnectionThread(HandoverConnectionThread* pThread)
 {
-  if (mConnectionThread != NULL) {
+  if (pThread != NULL && mConnectionThread != NULL) {
     ALOGE("%s: there is more than one connection, should not happen!", FUNC);
   }
   mConnectionThread = pThread;


### PR DESCRIPTION
Coding error for printing debug message
