### PR TITLE
Bug 1071466 - [NFC] session id always 0 when nfcd notify p2p tech lost. ...

### DIFF
--- a/src/NfcService.cpp
+++ b/src/NfcService.cpp
@@ -194,7 +194,9 @@ void NfcService::handleLlcpLinkDeactivation(NfcEvent* event)
   }
 
   mP2pLinkManager->onLlcpDeactivated();
-  mMsgHandler->processNotification(NFC_NOTIFICATION_TECH_LOST, NULL);
+  mMsgHandler->processNotification(NFC_NOTIFICATION_TECH_LOST, 
+                                   reinterpret_cast<void*>(mP2pLinkManager->getSessionId()));
+  mP2pLinkManager->setSessionId(-1);
 }
 
 void NfcService::handleLlcpLinkActivation(NfcEvent* event)
@@ -235,7 +237,8 @@ void NfcService::handleLlcpLinkActivation(NfcEvent* event)
 
   TechDiscoveredEvent* data = new TechDiscoveredEvent();
 
-  data->sessionId = SessionId::generateNewId();
+  mP2pLinkManager->setSessionId(SessionId::generateNewId());
+  data->sessionId = mP2pLinkManager->getSessionId();
   data->techCount = 1;
   uint8_t techs[] = { NFC_TECH_P2P };
   data->techList = &techs;

--- a/src/P2pLinkManager.cpp
+++ b/src/P2pLinkManager.cpp
@@ -94,6 +94,7 @@ void HandoverCallback::onMessageReceived(NdefMessage* ndef)
 
 P2pLinkManager::P2pLinkManager(NfcService* service)
  : mLinkState(LINK_STATE_DOWN)
+ , mSessionId(-1)
  , mSnepClient(NULL)
  , mHandoverClient(NULL)
 {

--- a/src/P2pLinkManager.h
+++ b/src/P2pLinkManager.h
@@ -60,6 +60,9 @@ public:
   void onLlcpDeactivated();
   bool isLlcpActive();
 
+  void setSessionId(int sessionId) { mSessionId = sessionId; }
+  int getSessionId() { return mSessionId; }
+
 private:
   static const int LINK_STATE_DOWN = 1;
   static const int LINK_STATE_UP = 2;
@@ -69,6 +72,7 @@ private:
   void disconnectClients();
 
   int mLinkState;
+  int mSessionId;
 
   NfcService* mNfcService;
 


### PR DESCRIPTION
...r=allstars.chh
